### PR TITLE
Display timestamps in the local timezone with the TZ info

### DIFF
--- a/src/ccze.c
+++ b/src/ccze.c
@@ -357,7 +357,7 @@ ccze_print_date (const char *date)
 	  ccze_addstr (CCZE_COLOR_DATE, date);
 	  return;
 	}
-      strftime (tmp, sizeof (tmp) - 1, "%b %e %T", gmtime (&ltime));
+      strftime (tmp, sizeof (tmp) - 1, "%b %e %T %z", localtime(&ltime));
       ccze_addstr (CCZE_COLOR_DATE, tmp);
     }
   else


### PR DESCRIPTION
I have changed the formatting of timestamps to use the local timezone.
This fixes: #5 