### PR TITLE
docs: update the URL of colorize

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 This is CCZE, a fast log colorizer written in C, intended to be a
-drop-in replacement for colorize (http://colorize.raszi.hu).
+drop-in replacement for colorize (https://github.com/raszi/colorize).
 
 See the NEWS file for a description of recent changes to CCZE.
 


### PR DESCRIPTION
I am the author and maintainer of colorize. I can see that @algernoon moved away from GitHub and he also abandoned CCZE.

It would be great if you could update the README to point to the right location.